### PR TITLE
Updating to version 0.5.2

### DIFF
--- a/com.github.cfcurtis.pdfstitcher.desktop
+++ b/com.github.cfcurtis.pdfstitcher.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Version=1.0
+Version=0.5.2
 Name=PDF Stitcher
 GenericName=PDF Stitcher
 Comment=The open source PDF stitching software for sewists, by sewists.

--- a/com.github.cfcurtis.pdfstitcher.desktop
+++ b/com.github.cfcurtis.pdfstitcher.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Version=0.5.2
+Version=1.0
 Name=PDF Stitcher
 GenericName=PDF Stitcher
 Comment=The open source PDF stitching software for sewists, by sewists.

--- a/com.github.cfcurtis.pdfstitcher.json
+++ b/com.github.cfcurtis.pdfstitcher.json
@@ -54,7 +54,7 @@
             "sources": [
                 {
                   "type": "file",
-                  "url": "https://github.com/cfcurtis/pdfstitcher/archive/refs/tags/v0.5.zip",
+                  "url": "https://github.com/cfcurtis/pdfstitcher/archive/refs/tags/v0.5.2.zip",
                   "sha256": "77cd9f3d1e4559e8ea8d3c27fb36a7dcee8824d69d0f6457fb9b2a2c395909c8",
                   "dest-filename": "pdfstitcher.zip"
                 },

--- a/com.github.cfcurtis.pdfstitcher.json
+++ b/com.github.cfcurtis.pdfstitcher.json
@@ -55,7 +55,7 @@
                 {
                   "type": "file",
                   "url": "https://github.com/cfcurtis/pdfstitcher/archive/refs/tags/v0.5.2.zip",
-                  "sha256": "77cd9f3d1e4559e8ea8d3c27fb36a7dcee8824d69d0f6457fb9b2a2c395909c8",
+                  "sha256": "9ba704344821395f181b9ffc1bc21de31c4d392198b5761a9fa10ab5a3a73e77",
                   "dest-filename": "pdfstitcher.zip"
                 },
                 {

--- a/com.github.cfcurtis.pdfstitcher.metainfo.xml
+++ b/com.github.cfcurtis.pdfstitcher.metainfo.xml
@@ -35,9 +35,9 @@
   <update_contact>nbenitezl_AT_gmail.com</update_contact>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="0.5" date="2021-10-04">
-    <description>0.5 release</description>
-    <url>https://www.pdfstitcher.org/v0.5-release/</url>
+    <release version="0.5.2" date="2022-02-24">
+    <description>0.5.2 release</description>
+    <url>https://github.com/cfcurtis/pdfstitcher/releases/tag/v0.5.2/url>
     </release>
   </releases>
 </component>

--- a/com.github.cfcurtis.pdfstitcher.metainfo.xml
+++ b/com.github.cfcurtis.pdfstitcher.metainfo.xml
@@ -37,7 +37,7 @@
   <releases>
     <release version="0.5.2" date="2022-02-24">
     <description>0.5.2 release</description>
-    <url>https://github.com/cfcurtis/pdfstitcher/releases/tag/v0.5.2/url>
+    <url>https://github.com/cfcurtis/pdfstitcher/releases/tag/v0.5.2/</url>
     </release>
   </releases>
 </component>


### PR DESCRIPTION
I think I did this correctly, let me know if there is more required for updating versions.

I've also just finished automating release builds for Windows and MacOS, as well as publishing to PyPi. If there's a recommended procedure to add Flatpak builds to github actions, I'd be happy to do that as well.

One other thing - poking through the files I don't see anything about translations. I now have a setup.py script that handles compiling translation files, is there a way to switch the Flatpak build to use that?